### PR TITLE
Add Elide.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -782,6 +782,7 @@ A curated list of awesome Java frameworks, libraries and software.
 *Frameworks specifically for creating RESTful services.*
 
 - [Dropwizard](https://dropwizard.github.io/dropwizard) - Opinionated framework for setting up modern web applications with Jetty, Jackson, Jersey and Metrics.
+- [Elide.io](http://elide.io/) - Java library that enables you to stand up a JSON API or GraphQL web service with minimal effort starting from a JPA annotated data model.
 - [Jersey](https://jersey.github.io) - JAX-RS reference implementation.
 - [Microserver](https://github.com/aol/micro-server) — A convenient, extensible microservices plugin system for Spring & Spring Boot. With more than 30 plugins and growing, it supports both micro-monolith and pure microservices styles.
 - [Rapidoid](https://www.rapidoid.org) - A simple, secure and extremely fast framework consisting of an embedded HTTP server, GUI components and dependency injection.


### PR DESCRIPTION
Adding a new RESTful service - Elide

- Java library for a JSON API  or GraphQL web service
- very easy setup
- good documentation
- and is open sourced